### PR TITLE
Fix Incorrect Resources Bundle Configuration

### DIFF
--- a/Configurations/Framework.xcconfig
+++ b/Configurations/Framework.xcconfig
@@ -6,6 +6,8 @@ USE_HEADERMAP = NO
 DYLIB_COMPATIBILITY_VERSION = 1
 DYLIB_CURRENT_VERSION = 1
 
+CURRENT_PROJECT_VERSION = 1
+
 DYLIB_INSTALL_NAME_BASE = @rpath
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
 

--- a/STULabel/Resources/Info.plist
+++ b/STULabel/Resources/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -18,7 +16,5 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
 </dict>
 </plist>


### PR DESCRIPTION
In order to submit to the App Store, some plist configurations needed to be fixed.

Firstly, Apple requires a project version so I just supplied that via an xcconfig to be updated if need be.

Second, the resources bundle was referencing an executable that didn't exist so the archive utility would complain.