### PR TITLE
Migrate to Swift version 5.0

### DIFF
--- a/STULabel.xcodeproj/project.pbxproj
+++ b/STULabel.xcodeproj/project.pbxproj
@@ -2143,7 +2143,7 @@
 					};
 					D42382971F926F2C000B8A63 = {
 						CreatedOnToolsVersion = 9.1;
-						LastSwiftMigration = 0910;
+						LastSwiftMigration = 1110;
 					};
 					D42383CE1F92AC81000B8A63 = {
 						LastSwiftMigration = 1000;
@@ -2158,7 +2158,7 @@
 					};
 					D467A0761F9261E70043C7F0 = {
 						CreatedOnToolsVersion = 9.1;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1110;
 						ProvisioningStyle = Automatic;
 					};
 					D4B0AEBB1F9259E600B5B2B9 = {
@@ -2788,6 +2788,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D41310D21F94237400F39C3A /* STULabelSwift.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -2795,6 +2796,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D41310D21F94237400F39C3A /* STULabelSwift.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -2844,6 +2846,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D407F00920E52B6700922204 /* Demo.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -2851,6 +2854,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D407F00920E52B6700922204 /* Demo.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/STULabel.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/STULabel.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:STULabel.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"
@@ -53,6 +51,7 @@
       debugXPCServices = "NO"
       stopOnEveryThreadSanitizerIssue = "YES"
       stopOnEveryUBSanitizerIssue = "YES"
+      migratedStopOnEveryIssue = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       queueDebuggingEnabled = "No">
@@ -66,8 +65,6 @@
             ReferencedContainer = "container:STULabel.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/STULabelSwift.podspec
+++ b/STULabelSwift.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version  = '0.8.4'
   s.dependency 'STULabel', "~> 0.8.4"
   
-  s.swift_version = '4.2'
+  s.swift_version = '5.0'
   s.platform = :ios, '9.3'
 
   s.license  = { :type => '2-clause BSD', :file => 'LICENSE.txt' }


### PR DESCRIPTION
- Migrated with Xcode 11.1, no code changes required
- Updated swift_version in podspec to 5.0 so that the pod now works with `supports_swift_versions` in Podfile, which is officially introduced in cocoapods 1.7.0
