### PR TITLE
Fix Building for Xcode 11.4

### DIFF
--- a/STULabel/Internal/stu/TypeTraits.hpp
+++ b/STULabel/Internal/stu/TypeTraits.hpp
@@ -450,16 +450,16 @@ namespace detail {
 
 /// The minimum representable finite value.
 template <typename T>
-constexpr T minValue = IntegerTraits<T>::min;
+constexpr inline T minValue = IntegerTraits<T>::min;
 
 /// The maximum representable finite value.
 template <typename T>
-constexpr T maxValue = IntegerTraits<T>::max;
+constexpr inline T maxValue = IntegerTraits<T>::max;
 
-template <> constexpr float maxValue<float> =  FLT_MAX;
-template <> constexpr float minValue<float> = -FLT_MAX;
-template <> constexpr double maxValue<double> =  DBL_MAX;
-template <> constexpr double minValue<double> = -DBL_MAX;
+template <> constexpr inline float maxValue<float> =  FLT_MAX;
+template <> constexpr inline float minValue<float> = -FLT_MAX;
+template <> constexpr inline double maxValue<double> =  DBL_MAX;
+template <> constexpr inline double minValue<double> = -DBL_MAX;
 
 template <typename T, EnableIf<isOneOf<T, float, double>> = 0>
 constexpr T infinity = __builtin_inff();

--- a/STULabel/STUTextFrame.mm
+++ b/STULabel/STUTextFrame.mm
@@ -457,7 +457,7 @@ void stu_label::drawTextFrame(const STUTextFrame* NS_VALID_UNTIL_END_OF_SCOPE se
 
 // MARK: - Frame image bounds
 
-Rect<CGFloat> STUTextFrameGetImageBoundsForRange(
+stu_label::Rect<CGFloat> STUTextFrameGetImageBoundsForRange(
                 const STUTextFrame* __unsafe_unretained self,
                 STUTextFrameRange range,
                 CGPoint origin, CGFloat displayScale,


### PR DESCRIPTION
This fixes some issues with building for Xcode 11.4:

1. Rect gets confused with MacTypes (yay) so it needs to be marked explicitly as `stu_label::Rect`
2. There's loads of duplicate symbols for minValue / maxValue, so this just makes them inline… I don't know why they're being compiled as duplicates tho