### PR TITLE
Fix compile error in Xcode 15.3 beta 3

### DIFF
--- a/STULabel/Internal/TextStyleBuffer.hpp
+++ b/STULabel/Internal/TextStyleBuffer.hpp
@@ -7,6 +7,10 @@
 #import "Font.hpp"
 #import "HashTable.hpp"
 
+#if STU_DEBUG
+#include <exception>
+#endif
+
 namespace stu_label {
 
 extern NSString* const STUOriginalFontAttributeName;
@@ -35,7 +39,7 @@ public:
 
 #if STU_DEBUG
   ~TextStyleBuffer() {
-    if (!std::uncaught_exception()) {
+    if (std::uncaught_exceptions() == 0) {
       STU_DEBUG_ASSERT(!needToFixAttachmentAttributes_);
     }
   }


### PR DESCRIPTION
`std::uncaught_exception` is apparently no more as of Xcode 15.3.