### PR TITLE
Fix deadlock running tests in Xcode 16

### DIFF
--- a/STULabel/STUMainScreenProperties.h
+++ b/STULabel/STUMainScreenProperties.h
@@ -14,6 +14,11 @@ STU_DISABLE_CLANG_WARNING("-Wunguarded-availability")
 STU_REENABLE_CLANG_WARNING
 };
 
+/// This function is normally executed automatically when the library is loaded from an Objective C @c load initialization method.
+/// If this leads to issues, you can define an @c STULabel_NoMainScreenPropertiesInitializationOnLoad environment variable
+/// and then call this function explicity from the main thread before using any of the STULabel functionality.
+void stu_initializeMainScreenProperties(void);
+
 /// Returns the value of @c UIScreen.main.fixedCoordinateSpace.bounds.size.
 /// Thread-safe.
 CGSize stu_mainScreenPortraitSize(void);


### PR DESCRIPTION
Fixes #56 by checking in the load initializer whether an XCTest environment variable is set and if so, dispatch the initialization asynchronously on the main thread. 
Also provides a way for disabling the load time initialization with the environment variable `STULabel_NoMainScreenPropertiesInitializationOnLoad` and then explicitly performing the initialization with the `stu_initializeMainScreenProperties` function.