### PR TITLE
Fix compile errors and warning in Xcode 26.0 beta 1

### DIFF
--- a/STULabel/Internal/stu/Iterator.hpp
+++ b/STULabel/Internal/stu/Iterator.hpp
@@ -6,6 +6,7 @@
 #import "stu/Comparable.hpp"
 #import "stu/TypeTraits.hpp"
 
+#include <cstddef>
 #include <iterator>
 
 namespace stu {

--- a/STULabel/Internal/stu/Optional.hpp
+++ b/STULabel/Internal/stu/Optional.hpp
@@ -7,6 +7,8 @@
 #include "stu/Utility.hpp"
 #include "stu/Ref.hpp"
 
+#include <exception>
+
 namespace stu {
 
 /// std::nullopt_t with a nicer name.

--- a/STULabel/Internal/stu/Ref.hpp
+++ b/STULabel/Internal/stu/Ref.hpp
@@ -4,6 +4,8 @@
 
 #include "stu/TypeTraits.hpp"
 
+#include <functional>
+
 namespace stu {
 
 template <typename T>

--- a/STULabel/Internal/stu/RefCounting.hpp
+++ b/STULabel/Internal/stu/RefCounting.hpp
@@ -4,6 +4,8 @@
 
 #include "stu/Utility.hpp"
 
+#include <cstddef>
+
 #if __OBJC__
   #include <Foundation/Foundation.h>
 #endif

--- a/STULabel/Internal/stu/UniquePtr.hpp
+++ b/STULabel/Internal/stu/UniquePtr.hpp
@@ -4,6 +4,8 @@
 
 #include "stu/Allocation.hpp"
 
+#include <cstddef>
+
 namespace stu {
 
 template <typename T>

--- a/STULabel/STUTextAttachment.mm
+++ b/STULabel/STUTextAttachment.mm
@@ -360,7 +360,7 @@ static STUTextAttachmentColorInfo attachmentColorInfoForColorSpace(CGColorSpaceR
       }
     }
     if (NSString* const value = attachment.accessibilityLanguage) {
-      self.accessibilityLanguage = attachment.accessibilityLanguage;
+      self.accessibilityLanguage = value;
     }
   }
   return self;


### PR DESCRIPTION
I think libc++ headers dropped some includes so we can no longer take transitive advantage.

The warning was about unused `value`, I figure the redundant lookup was an oversight :)